### PR TITLE
Avoid falling into an infinite cycle due to PHI loop

### DIFF
--- a/src/lib/MLTA.cc
+++ b/src/lib/MLTA.cc
@@ -1157,20 +1157,17 @@ bool MLTA::nextLayerBaseType(Value *V, list<typeidx_t> &TyList,
 	else if (PHINode *PN = dyn_cast<PHINode>(V)) {
 		// FIXME: tracking incoming values
 		bool ret = false;
-		set<Value *> NVisited;
 		list<typeidx_t> NTyList;
 		for (unsigned i = 0, e = PN->getNumIncomingValues(); i != e; ++i) {
 			Value *IV = PN->getIncomingValue(i);
 			NextV = IV;
-			NVisited = Visited;
 			NTyList = TyList;
-			ret = nextLayerBaseType(IV, NTyList, NextV, NVisited);
+			ret = nextLayerBaseType(IV, NTyList, NextV, Visited);
 			if (NTyList.size() > TyList.size()) {
 				break;
 			}
 		}
 		TyList = NTyList;
-		Visited = NVisited;
 		return ret;
 	}
 	else if (SelectInst *SelI = dyn_cast<SelectInst>(V)) {


### PR DESCRIPTION
This bug can be exposed by [mem.bc](https://github.com/umnsec/linux-bitcode/blob/d2a7b41d969d7d84d62d52a0b0a9412cb034c3ba/linux-5.3.0/drivers/infiniband/hw/mlx5/mem.bc)