### PR TITLE
Fix array type mismatching problem

### DIFF
--- a/src/lib/Common.cc
+++ b/src/lib/Common.cc
@@ -477,7 +477,7 @@ size_t typeHash(Type *Ty) {
     // Compiler sometimes fails recoginize size of array (compiler
     // bug?), so let's just use the element type
 
-    //Ty = ATy->getElementType();
+    Ty = ATy->getElementType();
     raw_string_ostream rso(sig);
     Ty->print(rso);
     ty_str = rso.str() + "[array]";


### PR DESCRIPTION
In LLVM, the type of arrays is represented as strings formatted as "[SIZE x element type]", which should be consistent if the same array is referred. However, LLVM will sometimes drop the SIZE information during access it. For example, in Linux v6.5, the `sys_call_table` is initialized as `[452 x i64 (%struct.pt_regs*)*]` and is accessed as `[0 x i64 (%struct.pt_regs*)*]`.
This is because, LLVM doesn't need to know the size of an array to access it. But it will introduce false negatives in MLTA, which is mentioned in the comment at `Common.cc:477` and `478`.

In this patch, I uncomment `Common.cc:480` to use the "element type" instead of type string in IR to represent an array, so that the initialization and accesses of an array have a consistent type.